### PR TITLE
Remove package scripts rendered obsolete by type-aware linting

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,9 +6,8 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev --port 3001 --turbopack",
-    "quality:lint:check": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --max-warnings 0",
-    "quality:lint:format": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --fix --max-warnings 0",
-    "quality:types:check": "tsc --noEmit",
+    "lint:check": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --max-warnings 0",
+    "lint:format": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --fix --max-warnings 0",
     "start": "next start"
   },
   "dependencies": {

--- a/apps/emergence/package.json
+++ b/apps/emergence/package.json
@@ -6,9 +6,8 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev --port 9000 --turbopack",
-    "quality:lint:check": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --max-warnings 0",
-    "quality:lint:format": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --fix --max-warnings 0",
-    "quality:types:check": "tsc --noEmit",
+    "lint:check": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --max-warnings 0",
+    "lint:format": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --fix --max-warnings 0",
     "start": "next start"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,9 +6,8 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev --port 3000 --turbopack",
-    "quality:lint:check": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --max-warnings 0",
-    "quality:lint:format": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --fix --max-warnings 0",
-    "quality:types:check": "tsc --noEmit",
+    "lint:check": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --max-warnings 0",
+    "lint:format": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --fix --max-warnings 0",
     "start": "next start"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,8 @@
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",
-    "quality:all:check": "turbo run quality:lint:check quality:types:check",
-    "quality:lint:check": "turbo run quality:lint:check",
-    "quality:lint:format": "turbo run quality:lint:format",
-    "quality:types:check": "turbo run quality:types:check",
+    "lint:check": "turbo run lint:check",
+    "lint:format": "turbo run lint:format",
     "turbo:daemon:reload": "turbo daemon clean"
   },
   "devDependencies": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -12,9 +12,8 @@
     "./typescript/react.json": "./src/typescript/react.json"
   },
   "scripts": {
-    "quality:lint:check": "eslint . --max-warnings 0",
-    "quality:lint:format": "eslint . --fix --max-warnings 0",
-    "quality:types:check": "tsc --noEmit"
+    "lint:check": "eslint . --max-warnings 0",
+    "lint:format": "eslint . --fix --max-warnings 0"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -9,9 +9,8 @@
     "./roboto": "./src/roboto.ts"
   },
   "scripts": {
-    "quality:lint:check": "eslint . --max-warnings 0",
-    "quality:lint:format": "eslint . --fix --max-warnings 0",
-    "quality:types:check": "tsc --noEmit",
+    "lint:check": "eslint . --max-warnings 0",
+    "lint:format": "eslint . --fix --max-warnings 0",
     "react:component:generate": "turbo gen react-component"
   },
   "dependencies": {

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -7,9 +7,8 @@
     "./*": "./src/*.tsx"
   },
   "scripts": {
-    "quality:lint:check": "eslint . --max-warnings 0",
-    "quality:lint:format": "eslint . --fix --max-warnings 0",
-    "quality:types:check": "tsc --noEmit",
+    "lint:check": "eslint . --max-warnings 0",
+    "lint:format": "eslint . --fix --max-warnings 0",
     "react:component:generate": "turbo gen react-component"
   },
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,9 +7,8 @@
     "./*": "./src/*.tsx"
   },
   "scripts": {
-    "quality:lint:check": "eslint . --max-warnings 0",
-    "quality:lint:format": "eslint . --fix --max-warnings 0",
-    "quality:types:check": "tsc --noEmit",
+    "lint:check": "eslint . --max-warnings 0",
+    "lint:format": "eslint . --fix --max-warnings 0",
     "react:component:generate": "turbo gen react-component"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -18,19 +18,14 @@
       "cache": false,
       "persistent": true
     },
-    "quality:lint:check": {
+    "lint:check": {
       "dependsOn": [
-        "^quality:lint:check"
+        "^lint:check"
       ]
     },
-    "quality:lint:format": {
+    "lint:format": {
       "dependsOn": [
-        "^quality:lint:format"
-      ]
-    },
-    "quality:types:check": {
-      "dependsOn": [
-        "^quality:types:check"
+        "^lint:format"
       ]
     }
   },


### PR DESCRIPTION
In all apps/projects, `lint:(check|format)` replaces `quality:(lint|types):(check|format)`, removing redundant `tsc`-calling scripts, which is now possible due to type-aware linting.