### PR TITLE
`import-x` renaming

### DIFF
--- a/packages/config/src/eslint/base/base.ts
+++ b/packages/config/src/eslint/base/base.ts
@@ -1,7 +1,7 @@
 import { configs as jsConfigs } from '@eslint/js'
 import { config, type ConfigArray } from 'typescript-eslint'
 import { ignores } from './ignores.js'
-import { importConfig } from './import.js'
+import { importX } from './importX.js'
 import { json } from './json.js'
 import { noUnsanitized } from './noUnsanitized.js'
 import { onlyWarn } from './onlyWarn.js'
@@ -16,7 +16,7 @@ export const base: ConfigArray = config([
   ...json,
   ...turbo,
   ...onlyWarn,
-  ...importConfig,
+  ...importX,
   ...ignores,
   ...prettier,
 ])

--- a/packages/config/src/eslint/base/importX.ts
+++ b/packages/config/src/eslint/base/importX.ts
@@ -3,9 +3,13 @@ import { importX as importXPlugin } from 'eslint-plugin-import-x'
 import { config } from 'typescript-eslint'
 import { type ConfigArray } from 'typescript-eslint'
 
+const {
+  flatConfigs: { recommended, typescript },
+} = importXPlugin
+
 export const importX: ConfigArray = config([
-  importXPlugin.flatConfigs.recommended,
-  importXPlugin.flatConfigs.typescript,
+  recommended,
+  typescript,
   {
     languageOptions: {
       parser,

--- a/packages/config/src/eslint/base/importX.ts
+++ b/packages/config/src/eslint/base/importX.ts
@@ -1,11 +1,11 @@
 import parser from '@typescript-eslint/parser'
-import { importX } from 'eslint-plugin-import-x'
+import { importX as importXPlugin } from 'eslint-plugin-import-x'
 import { config } from 'typescript-eslint'
 import { type ConfigArray } from 'typescript-eslint'
 
-export const importConfig: ConfigArray = config([
-  importX.flatConfigs.recommended,
-  importX.flatConfigs.typescript,
+export const importX: ConfigArray = config([
+  importXPlugin.flatConfigs.recommended,
+  importXPlugin.flatConfigs.typescript,
   {
     languageOptions: {
       parser,

--- a/packages/config/src/eslint/base/prettier.ts
+++ b/packages/config/src/eslint/base/prettier.ts
@@ -3,6 +3,8 @@ import prettierPluginRecommended from 'eslint-plugin-prettier/recommended'
 import { config, type ConfigArray } from 'typescript-eslint'
 
 export const prettier: ConfigArray = config([
+  prettierConfig,
+  prettierPluginRecommended,
   {
     rules: {
       'prettier/prettier': [
@@ -19,6 +21,4 @@ export const prettier: ConfigArray = config([
       ],
     },
   },
-  prettierConfig,
-  prettierPluginRecommended,
 ])


### PR DESCRIPTION
`importX` renamed from `importConfig`, following extant conventions established by sibling configurations.