### PR TITLE
ESLint: Consistent `type` declarations

### DIFF
--- a/packages/config/src/eslint/base/typeScript.ts
+++ b/packages/config/src/eslint/base/typeScript.ts
@@ -14,5 +14,8 @@ export const typeScript: ConfigArray = config([
         tsconfigRootDir: '.',
       },
     },
+    rules: {
+      '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+    },
   },
 ])


### PR DESCRIPTION
`interface` declarations are prohibited in favor of composable `type` declarations (and object literals).