### PR TITLE
Automatic TS config lookup in `typescript-eslint`

### DIFF
--- a/packages/config/src/eslint/base/typeScript/typeScript.ts
+++ b/packages/config/src/eslint/base/typeScript/typeScript.ts
@@ -8,10 +8,7 @@ export const typeScript: ConfigArray = config([
     extends: [strictTypeChecked, stylisticTypeChecked],
     ignores: ['**/*.json'],
     languageOptions: {
-      parserOptions: {
-        projectService: true,
-        tsconfigRootDir: '.',
-      },
+      parserOptions: { projectService: true },
     },
     rules: {
       '@typescript-eslint/consistent-type-definitions': ['error', 'type'],


### PR DESCRIPTION
`typescript-eslint`'s `parserOptions.tsconfigRootDir` set to `undefined`, defaulting to automatic TS config lookup.

Enables compatibility with future versions of `typescript-eslint` that disallow relative paths including the former value `.`.