### PR TITLE
ESLint replaces deprecated `next lint`

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev --port 3001 --turbopack",
-    "lint:check": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --max-warnings 0",
-    "lint:format": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --fix --max-warnings 0",
+    "lint:check": "eslint . --max-warnings 0",
+    "lint:format": "eslint . --fix --max-warnings 0",
     "start": "next start",
     "types:generate": "next typegen"
   },

--- a/apps/emergence/package.json
+++ b/apps/emergence/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev --port 9000 --turbopack",
-    "lint:check": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --max-warnings 0",
-    "lint:format": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --fix --max-warnings 0",
+    "lint:check": "eslint . --max-warnings 0",
+    "lint:format": "eslint . --fix --max-warnings 0",
     "start": "next start",
     "types:generate": "next typegen"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev --port 3000 --turbopack",
-    "lint:check": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --max-warnings 0",
-    "lint:format": "next lint --dir . --ext .js,.jsx,.ts,.tsx,.json --fix --max-warnings 0",
+    "lint:check": "eslint . --max-warnings 0",
+    "lint:format": "eslint . --fix --max-warnings 0",
     "start": "next start",
     "types:generate": "next typegen"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1096,8 +1096,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001741:
-    resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
+  caniuse-lite@1.0.30001743:
+    resolution: {integrity: sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2985,7 +2985,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001741: {}
+  caniuse-lite@1.0.30001743: {}
 
   chalk@4.1.2:
     dependencies:
@@ -3767,7 +3767,7 @@ snapshots:
     dependencies:
       '@next/env': 15.5.3
       '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001741
+      caniuse-lite: 1.0.30001743
       postcss: 8.4.31
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)


### PR DESCRIPTION
ESLint replaces the deprecated `next lint` command, enforcing global consistency and enabling compatibility with the upcoming Next.js v16 release.